### PR TITLE
Fixed modules so they can now control power output 

### DIFF
--- a/src/main/java/org/montclairrobotics/sprocket/motors/Module.java
+++ b/src/main/java/org/montclairrobotics/sprocket/motors/Module.java
@@ -2,6 +2,7 @@ package org.montclairrobotics.sprocket.motors;
 
 import org.montclairrobotics.sprocket.geometry.Distance;
 import org.montclairrobotics.sprocket.utils.Debug;
+import org.montclairrobotics.sprocket.utils.Input;
 import org.montclairrobotics.sprocket.utils.PID;
 
 /**
@@ -26,8 +27,7 @@ public class Module {
     private SEncoder enc;
     private PID pid;
     private MotorInputType inputType;
-    
-    private Distance maxSpeed;
+
     private int moduleId;
     
     /**
@@ -53,10 +53,9 @@ public class Module {
 
 
 
-        if(pid!=null)
-        	pid.setInput(enc);
+        if(pid!=null && enc !=null)
+        	pid.setInput(() -> enc.getScaledSpeed());
         
-        this.maxSpeed=new Distance(1);
         this.moduleId = id;
         id++;
     }
@@ -78,7 +77,7 @@ public class Module {
     	{
     		Debug.msg("motordebug", "Using encoders");
             pid.setTarget(power);
-            power=(power+pid.get())/maxSpeed.get();
+            power=(power+pid.get());
     	}
     	for(Motor motor:motors)
     	{

--- a/src/main/java/org/montclairrobotics/sprocket/motors/SEncoder.java
+++ b/src/main/java/org/montclairrobotics/sprocket/motors/SEncoder.java
@@ -12,17 +12,19 @@ public class SEncoder implements Input<Double> {
     private Encoder enc;
     private int eId;
     private double ticksPerInch;
+    private double maxSpeed;
 
 
-    public SEncoder(int a, int b, double ticksPerInch, boolean reverse) {
+    public SEncoder(int a, int b, double ticksPerInch, double maxSpeed, boolean reverse) {
         enc = new Encoder(a, b, reverse);
         eId = a;
         Debug.msg("enc-" + eId, "init");
         this.ticksPerInch = ticksPerInch;
+        this.maxSpeed = maxSpeed;
     }
 
-    public SEncoder(int a, int b, double ticksPerInch) {
-        this(a, b, ticksPerInch, false);
+    public SEncoder(int a, int b, double ticksPerInch, double maxSpeed) {
+        this(a, b, ticksPerInch, maxSpeed, false);
     }
 
     public SEncoder(Encoder e, double ticksPerInch) {
@@ -51,6 +53,10 @@ public class SEncoder implements Input<Double> {
 
     public void reset() {
         enc.reset();
+    }
+
+    public double getScaledSpeed(){
+        return getTickRate() / maxSpeed;
     }
 
     public Encoder getWPIEncoder() {


### PR DESCRIPTION
A pretty simple fix, just added a method in the encoder class that scales the output of the motor speed from 0 - 1 so that it can be controlled by the PID in the module class. This isn't tested and I don't know if it will work but it seems right. 